### PR TITLE
Add rejected articles documentation and related functionality

### DIFF
--- a/scripts/publish_docs.py
+++ b/scripts/publish_docs.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 
 from reporters.docs_publisher import (
     initialize_docs_directory,
-    publish_structured_docs,
+    publish_structured_docs
 )
 
 

--- a/scripts/reporters/docs_publisher.py
+++ b/scripts/reporters/docs_publisher.py
@@ -437,11 +437,14 @@ Newsbot is an automated news aggregator that searches for the latest articles, a
 ### [GitHub Repositories](repositories.md)
 Browse all discovered GitHub repositories in a searchable table format.
 
+### [Rejected Articles](rejected.md)
+View all articles that were evaluated but rejected from publication due to relevance or credibility criteria.
+
 ## Latest Articles
 
 """
     
-    # Ensure the repositories link exists
+    # Ensure the Content section exists with repositories link and rejected articles link
     if "## Content" not in index_content:
         # Add content section before latest articles
         if "## Latest Articles" in index_content or "## Latest Reports" in index_content:
@@ -454,7 +457,19 @@ Browse all discovered GitHub repositories in a searchable table format.
 ### [GitHub Repositories](repositories.md)
 Browse all discovered GitHub repositories in a searchable table format.
 
+### [Rejected Articles](rejected.md)
+View all articles that were evaluated but rejected from publication due to relevance or credibility criteria.
+
 """ + remaining
+    elif "rejected.md" not in index_content:
+        # Add rejected articles link to existing Content section
+        if "### [GitHub Repositories](repositories.md)" in index_content:
+            index_content = index_content.replace(
+                "Browse all discovered GitHub repositories in a searchable table format.\n",
+                "Browse all discovered GitHub repositories in a searchable table format.\n\n"
+                "### [Rejected Articles](rejected.md)\n"
+                "View all articles that were evaluated but rejected from publication due to relevance or credibility criteria.\n"
+            )
     
     # Update or add articles section
     if article_entries and rss_count > 0:
@@ -556,13 +571,14 @@ Browse all discovered GitHub repositories in a searchable table format.
 
 
 def publish_structured_docs(results: List[Dict[str, Any]], timestamp: str,
-                           docs_dir: str = "docs") -> Dict[str, Any]:
+                           docs_dir: str = "docs", output_dir: str = "outputs") -> Dict[str, Any]:
     """Publish documentation in the new structured format.
     
     Args:
         results: List of all results (GitHub repos and RSS articles)
         timestamp: Timestamp for this batch (YYYYMMDD_HHMMSS format)
         docs_dir: Target docs directory
+        output_dir: Output directory containing rejected articles (default: "outputs")
         
     Returns:
         Dictionary with paths to published files
@@ -577,6 +593,7 @@ def publish_structured_docs(results: List[Dict[str, Any]], timestamp: str,
     published_files = {
         "repositories": None,
         "articles": [],
+        "rejected": None,
         "index": os.path.join(docs_dir, "index.md")
     }
     
@@ -591,6 +608,11 @@ def publish_structured_docs(results: List[Dict[str, Any]], timestamp: str,
         article_entries = publish_rss_article_pages(rss_items, timestamp, docs_dir)
         published_files["articles"] = [entry["path"] for entry in article_entries]
     
+    # Publish rejected articles page
+    rejected_path = publish_rejected_articles_page(output_dir, docs_dir)
+    if rejected_path:
+        published_files["rejected"] = rejected_path
+    
     # Update index with structured content
     update_index_with_structured_content(
         docs_dir, timestamp, 
@@ -599,3 +621,162 @@ def publish_structured_docs(results: List[Dict[str, Any]], timestamp: str,
     )
     
     return published_files
+
+
+def load_rejected_articles(output_dir: str = "outputs") -> List[Dict[str, Any]]:
+    """Load and aggregate all rejected articles from JSON files.
+    
+    Args:
+        output_dir: Directory containing rejected_*.json files
+        
+    Returns:
+        List of all rejected articles from all JSON files
+    """
+    rejected_articles = []
+    
+    if not os.path.exists(output_dir):
+        logging.warning(f"Output directory not found: {output_dir}")
+        return rejected_articles
+    
+    # Find all rejected JSON files
+    for filename in os.listdir(output_dir):
+        if filename.startswith("rejected_") and filename.endswith(".json"):
+            filepath = os.path.join(output_dir, filename)
+            try:
+                with open(filepath, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    if isinstance(data, list):
+                        rejected_articles.extend(data)
+                        logging.info(f"Loaded {len(data)} rejected articles from {filename}")
+            except (json.JSONDecodeError, IOError) as e:
+                logging.warning(f"Could not read rejected articles from {filename}: {e}")
+    
+    logging.info(f"Total rejected articles loaded: {len(rejected_articles)}")
+    return rejected_articles
+
+
+def generate_rejected_articles_page(rejected_articles: List[Dict[str, Any]]) -> str:
+    """Generate the rejected articles documentation page content.
+    
+    Args:
+        rejected_articles: List of rejected article dictionaries
+        
+    Returns:
+        Markdown content for the rejected articles page
+    """
+    content = """# Rejected Articles
+
+This page lists all articles that were evaluated but rejected from publication. Articles are rejected when they do not meet Newsbot's relevance or credibility criteria.
+
+## What Constitutes a "Rejected" Article?
+
+Articles are rejected for the following reasons:
+
+### Rejection Type: Relevance
+
+Articles can be rejected as not relevant if they:
+
+1. **Missing AI Keywords** (`missing_ai_keywords`): GitHub repositories that lack keywords related to AI, automation, or fuzzing in offensive security contexts. These repositories may be related to security but don't involve the use of AI or automation.
+
+2. **LLM Applicability Below Threshold** (`llm_applicability_below_threshold`): RSS feed articles that were assessed by the LLM (Large Language Model) but scored below the configured applicability threshold. This typically means:
+   - The article doesn't contain sufficient content about offensive security topics (penetration testing, red team operations, vulnerability research, exploit development, etc.), OR
+   - The article doesn't explicitly describe the **use** of AI, automation, or fuzzing techniques
+
+   Both requirements must be satisfied for an article to be considered applicable.
+
+### Rejection Type: Credibility
+
+1. **LLM Credibility Below Threshold** (`llm_credibility_below_threshold`): RSS feed articles that scored below the configured credibility threshold. This indicates potential issues with:
+   - Source reliability
+   - Content quality or accuracy
+   - Lack of technical depth
+   - Promotional or marketing-focused content
+
+## Rejected Articles Table
+
+Total rejected articles: **{total}**
+
+| Title | Topic | Rejection Type | Rejection Reason |
+|-------|-------|----------------|------------------|
+"""
+    
+    # Sort articles by topic, then by rejection type
+    sorted_articles = sorted(
+        rejected_articles,
+        key=lambda x: (
+            x.get('topic', 'unknown'),
+            x.get('rejection_type', 'unknown'),
+            x.get('title', 'Untitled')
+        )
+    )
+    
+    # Add table rows
+    for article in sorted_articles:
+        title = article.get('title', 'Untitled')
+        url = article.get('url', '')
+        topic = article.get('topic', 'N/A')
+        rejection_type = article.get('rejection_type', 'N/A')
+        rejection_reason = article.get('rejection_reason', 'N/A')
+        
+        # Format title as link if URL is available
+        if url:
+            title_cell = f"[{title}]({url})"
+        else:
+            title_cell = title
+        
+        # Format rejection reason with threshold if available
+        rejection_threshold = article.get('rejection_threshold')
+        if rejection_threshold is not None:
+            rejection_reason_cell = f"{rejection_reason} (threshold: {rejection_threshold})"
+        else:
+            rejection_reason_cell = rejection_reason
+        
+        content += f"| {title_cell} | {topic} | {rejection_type} | {rejection_reason_cell} |\n"
+    
+    content = content.format(total=len(rejected_articles))
+    
+    content += """
+---
+
+[← Back to Index](index.md)
+"""
+    
+    return content
+
+
+def publish_rejected_articles_page(output_dir: str = "outputs", docs_dir: str = "docs") -> Optional[str]:
+    """Publish the rejected articles page to docs.
+    
+    Args:
+        output_dir: Directory containing rejected_*.json files
+        docs_dir: Target docs directory
+        
+    Returns:
+        Path to the published rejected articles page, or None if failed
+    """
+    # Load all rejected articles
+    rejected_articles = load_rejected_articles(output_dir)
+    
+    if not rejected_articles:
+        logging.warning("No rejected articles found, skipping rejected articles page")
+        return None
+    
+    # Generate page content
+    page_content = generate_rejected_articles_page(rejected_articles)
+    
+    # Add front matter
+    formatted_content = "---\nlayout: default\ntitle: Rejected Articles\n---\n\n"
+    formatted_content += page_content
+    
+    # Write to docs directory
+    rejected_path = os.path.join(docs_dir, "rejected.md")
+    try:
+        with open(rejected_path, 'w', encoding='utf-8') as f:
+            f.write(formatted_content)
+        logging.info(f"Published rejected articles page to: {rejected_path}")
+        return rejected_path
+    except IOError as e:
+        logging.error(f"Failed to publish rejected articles page: {e}")
+        return None
+
+

--- a/tests/test_docs_publisher.py
+++ b/tests/test_docs_publisher.py
@@ -13,7 +13,10 @@ import pytest
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
 from reporters.docs_publisher import (
-    initialize_docs_directory
+    initialize_docs_directory,
+    load_rejected_articles,
+    generate_rejected_articles_page,
+    publish_rejected_articles_page
 )
 
 
@@ -285,6 +288,235 @@ class TestStructuredPublishing:
             
             assert "[GitHub Repositories](repositories.md)" in content
             assert "## Latest Articles" in content
+
+
+class TestRejectedArticles:
+    """Tests for rejected articles functionality."""
+    
+    def test_load_rejected_articles_empty_directory(self):
+        """Test loading rejected articles from empty directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rejected = load_rejected_articles(tmpdir)
+            assert rejected == []
+    
+    def test_load_rejected_articles_no_files(self):
+        """Test loading when directory exists but has no rejected JSON files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create some other files
+            with open(os.path.join(tmpdir, "results.json"), 'w') as f:
+                json.dump([], f)
+            
+            rejected = load_rejected_articles(tmpdir)
+            assert rejected == []
+    
+    def test_load_rejected_articles_single_file(self):
+        """Test loading rejected articles from a single file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a rejected articles file
+            rejected_data = [
+                {
+                    "title": "Test Article 1",
+                    "url": "https://example.com/1",
+                    "topic": "security",
+                    "rejection_type": "relevance",
+                    "rejection_reason": "missing_ai_keywords"
+                },
+                {
+                    "title": "Test Article 2",
+                    "url": "https://example.com/2",
+                    "topic": "malware",
+                    "rejection_type": "credibility",
+                    "rejection_reason": "llm_credibility_below_threshold",
+                    "rejection_threshold": 0.6
+                }
+            ]
+            
+            with open(os.path.join(tmpdir, "rejected_20260215_120000.json"), 'w') as f:
+                json.dump(rejected_data, f)
+            
+            rejected = load_rejected_articles(tmpdir)
+            assert len(rejected) == 2
+            assert rejected[0]["title"] == "Test Article 1"
+            assert rejected[1]["rejection_type"] == "credibility"
+    
+    def test_load_rejected_articles_multiple_files(self):
+        """Test loading rejected articles from multiple files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create multiple rejected articles files
+            for i in range(3):
+                rejected_data = [
+                    {
+                        "title": f"Article {i}",
+                        "url": f"https://example.com/{i}",
+                        "topic": "security",
+                        "rejection_type": "relevance",
+                        "rejection_reason": "missing_ai_keywords"
+                    }
+                ]
+                
+                with open(os.path.join(tmpdir, f"rejected_2026021{i}_120000.json"), 'w') as f:
+                    json.dump(rejected_data, f)
+            
+            rejected = load_rejected_articles(tmpdir)
+            assert len(rejected) == 3
+    
+    def test_generate_rejected_articles_page(self):
+        """Test generating rejected articles page content."""
+        rejected_data = [
+            {
+                "title": "Test Article",
+                "url": "https://example.com/test",
+                "topic": "security",
+                "rejection_type": "relevance",
+                "rejection_reason": "missing_ai_keywords"
+            },
+            {
+                "title": "Another Article",
+                "url": "https://example.com/another",
+                "topic": "malware",
+                "rejection_type": "credibility",
+                "rejection_reason": "llm_credibility_below_threshold",
+                "rejection_threshold": 0.6
+            }
+        ]
+        
+        content = generate_rejected_articles_page(rejected_data)
+        
+        # Check for expected sections
+        assert "# Rejected Articles" in content
+        assert "## What Constitutes a \"Rejected\" Article?" in content
+        assert "## Rejected Articles Table" in content
+        
+        # Check table header
+        assert "| Title | Topic | Rejection Type | Rejection Reason |" in content
+        
+        # Check table content
+        assert "[Test Article](https://example.com/test)" in content
+        assert "missing_ai_keywords" in content
+        assert "llm_credibility_below_threshold (threshold: 0.6)" in content
+        
+        # Check total count
+        assert "Total rejected articles: **2**" in content
+        
+        # Check navigation
+        assert "[← Back to Index](index.md)" in content
+    
+    def test_generate_rejected_articles_page_no_url(self):
+        """Test generating page with articles without URLs."""
+        rejected_data = [
+            {
+                "title": "Test Article",
+                "topic": "security",
+                "rejection_type": "relevance",
+                "rejection_reason": "missing_ai_keywords"
+            }
+        ]
+        
+        content = generate_rejected_articles_page(rejected_data)
+        
+        # Title should not be a link if URL is missing
+        assert "Test Article" in content
+        assert "[Test Article]" not in content
+    
+    def test_publish_rejected_articles_page(self):
+        """Test publishing rejected articles page."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docs_dir = os.path.join(tmpdir, "docs")
+            output_dir = os.path.join(tmpdir, "outputs")
+            os.makedirs(output_dir, exist_ok=True)
+            os.makedirs(docs_dir, exist_ok=True)
+            
+            # Create rejected articles data
+            rejected_data = [
+                {
+                    "title": "Test Article",
+                    "url": "https://example.com/test",
+                    "topic": "security",
+                    "rejection_type": "relevance",
+                    "rejection_reason": "missing_ai_keywords"
+                }
+            ]
+            
+            with open(os.path.join(output_dir, "rejected_20260215_120000.json"), 'w') as f:
+                json.dump(rejected_data, f)
+            
+            # Publish the page
+            result = publish_rejected_articles_page(output_dir, docs_dir)
+            
+            assert result is not None
+            assert os.path.exists(result)
+            assert result.endswith("rejected.md")
+            
+            # Verify content
+            with open(result, 'r') as f:
+                content = f.read()
+            
+            assert "layout: default" in content
+            assert "title: Rejected Articles" in content
+            assert "[Test Article](https://example.com/test)" in content
+    
+    def test_publish_rejected_articles_page_no_data(self):
+        """Test publishing when no rejected articles exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docs_dir = os.path.join(tmpdir, "docs")
+            output_dir = os.path.join(tmpdir, "outputs")
+            os.makedirs(output_dir, exist_ok=True)
+            
+            # No rejected articles files
+            result = publish_rejected_articles_page(output_dir, docs_dir)
+            
+            # Should return None when no data exists
+            assert result is None
+    
+    def test_publish_structured_docs_includes_rejected(self):
+        """Test that publish_structured_docs includes rejected articles page."""
+        from reporters.docs_publisher import publish_structured_docs
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            docs_dir = os.path.join(tmpdir, "docs")
+            output_dir = os.path.join(tmpdir, "outputs")
+            os.makedirs(output_dir, exist_ok=True)
+            
+            # Create rejected articles data
+            rejected_data = [
+                {
+                    "title": "Rejected Article",
+                    "url": "https://example.com/rejected",
+                    "topic": "security",
+                    "rejection_type": "relevance",
+                    "rejection_reason": "missing_ai_keywords"
+                }
+            ]
+            
+            with open(os.path.join(output_dir, "rejected_20260215_120000.json"), 'w') as f:
+                json.dump(rejected_data, f)
+            
+            # Create test results
+            results = [
+                {
+                    "source": "github",
+                    "title": "test-repo",
+                    "url": "https://github.com/user/test-repo",
+                    "description": "Test repository",
+                    "stars": 100,
+                    "updated": "2026-02-15T10:00:00Z",
+                    "topic": "security"
+                }
+            ]
+            
+            timestamp = "20260215_120000"
+            published = publish_structured_docs(results, timestamp, docs_dir, output_dir)
+            
+            # Check that rejected page was created
+            assert "rejected" in published
+            assert published["rejected"] is not None
+            assert os.path.exists(published["rejected"])
+            
+            # Verify content
+            with open(published["rejected"], 'r') as f:
+                content = f.read()
+            
+            assert "[Rejected Article](https://example.com/rejected)" in content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduce documentation and functionality for managing rejected articles. This includes a new section in the index, methods for loading and publishing rejected articles, and a detailed markdown page outlining the criteria for rejection. The changes enhance the overall documentation structure and provide clarity on article evaluation processes.

fixes #73